### PR TITLE
fix bug with regex validation

### DIFF
--- a/internal/model/property.go
+++ b/internal/model/property.go
@@ -70,7 +70,7 @@ func validateMaxLength(maxLength int, value string, propertyName string) error {
 }
 
 func validateRegex(regex string, value string, propertyName string) error {
-	if regex == "" {
+	if regex == "" || value == "" {
 		return nil
 	}
 


### PR DESCRIPTION
## what

- Fix a bug that occurred when  a property was not required and a value for that property was not specified, but regex validation was still be applied (and failing).
