### PR TITLE
fix bug with tag being rendered with "" value

### DIFF
--- a/internal/model/provider_config.go
+++ b/internal/model/provider_config.go
@@ -275,7 +275,9 @@ func (c *ProviderConfig) GetTags(values map[string]string, tagsKeyCase *cases.Ca
 	for _, p := range c.properties {
 		if p.IncludeInTags {
 			key, value := getCasedTag(p.Name, mergedValues[p.Name], megedTagsKeyCase, mergedTagsValueCase)
-			tags[key] = value
+			if value != "" {
+				tags[key] = value
+			}
 		}
 	}
 	return tags, nil

--- a/internal/provider/tags_data_source_test.go
+++ b/internal/provider/tags_data_source_test.go
@@ -41,6 +41,12 @@ func TestAccTagsDataSource(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccTagsEmptyValueCfg,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr("data.context_tags.test", "tags.Name"),
+				),
+			},
+			{
 				Config: testAccTagKeyCasedCfg,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.context_tags.test", "tags.NAMESPACE", "cp"),
@@ -67,6 +73,28 @@ provider "context" {
     "Tenant" = "core"
     "Stage" = "prod"
     "Name"  = "example"
+  }
+}
+
+
+data "context_tags" "test" {
+}
+`
+
+const testAccTagsEmptyValueCfg = `
+provider "context" {
+  properties = {
+    Namespace = {}
+    Tenant    = {}
+    Stage     = {}
+    Name      = {}
+  }
+
+  values = {
+    "Namespace" = "cp"
+    "Tenant" = "core"
+    "Stage" = "prod"
+    "Name"  = ""
   }
 }
 


### PR DESCRIPTION
## what

-Fix an issue in the `tags` data source where a property whose value is `""` is still rendered 
