### PR TITLE
add the ability to configure casing on a per-tag basis

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,6 +81,10 @@ jobs:
           - "1.5.*"
           - "1.6.*"
           - "1.7.*"
+          - "1.8.*"
+          - "1.9.*"
+          - "1.10.*"
+          - "1.11.*"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5

--- a/docs/data-sources/config.md
+++ b/docs/data-sources/config.md
@@ -39,4 +39,6 @@ Optional:
 - `max_length` (Number) The maximum length of the property.
 - `min_length` (Number) The minimum length of the property.
 - `required` (Boolean) A flag to indicate if the property is required.
+- `tags_key_case` (String) The case to use for the key of this property in tags.
+- `tags_value_case` (String) The case to use for the value of this property in tags.
 - `validation_regex` (String) A regular expression to validate the property.

--- a/docs/index.md
+++ b/docs/index.md
@@ -74,4 +74,6 @@ Optional:
 - `max_length` (Number) The maximum length of the property.
 - `min_length` (Number) The minimum length of the property.
 - `required` (Boolean) A flag to indicate if the property is required.
+- `tags_key_case` (String) The case to use for the key of this property in tags. If not set, uses the provider's tags_key_case setting. Valid values are: none, camel, lower, snake, title, upper.
+- `tags_value_case` (String) The case to use for the value of this property in tags. If not set, uses the provider's tags_value_case setting. Valid values are: none, camel, lower, snake, title, upper.
 - `validation_regex` (String) A regular expression to validate the property.

--- a/examples/data-sources/config/data-source.tf
+++ b/examples/data-sources/config/data-source.tf
@@ -23,8 +23,8 @@ provider "context" {
 }
 
 data "context_config" "example" {
-
 }
+
 
 locals {
   context = data.context_config.example

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -1,3 +1,40 @@
 provider "context" {
-  # example configuration here
+  delimiter       = "-"
+  enabled         = true
+  tags_key_case   = "title"
+  tags_value_case = "none"
+
+  properties = {
+    namespace = {
+      required        = true
+      include_in_tags = true
+      tags_key_case   = "upper"
+      tags_value_case = "upper"
+    }
+    environment = {
+      required        = true
+      include_in_tags = true
+      tags_key_case   = "lower"
+      tags_value_case = "lower"
+    }
+    stage = {
+      required        = false
+      include_in_tags = true
+      tags_key_case   = "snake"
+      tags_value_case = "snake"
+    }
+    name = {
+      required        = true
+      include_in_tags = true
+    }
+  }
+
+  values = {
+    namespace   = "TestNamespace"
+    environment = "TestEnvironment"
+    stage       = "TestStage"
+    name        = "TestName"
+  }
 }
+
+data "context_tags" "test" {}

--- a/internal/model/framework_property.go
+++ b/internal/model/framework_property.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"github.com/cloudposse/terraform-provider-context/pkg/cases"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
@@ -10,52 +11,74 @@ type FrameworkProperty struct {
 	MaxLength       types.Int64  `tfsdk:"max_length"`
 	MinLength       types.Int64  `tfsdk:"min_length"`
 	Required        types.Bool   `tfsdk:"required"`
+	TagsKeyCase     types.String `tfsdk:"tags_key_case"`
+	TagsValueCase   types.String `tfsdk:"tags_value_case"`
 	ValidationRegex types.String `tfsdk:"validation_regex"`
 }
 
-func (p *FrameworkProperty) addRequiredOption(options []func(*Property)) []func(*Property) {
+func (p *FrameworkProperty) addRequiredOption(options []PropertyOption) []PropertyOption {
 	if !p.Required.IsNull() && !p.Required.IsUnknown() && p.Required.ValueBool() {
 		return append(options, WithRequired())
 	}
 	return options
 }
 
-func (p *FrameworkProperty) addIncludeInTagsOption(options []func(*Property)) []func(*Property) {
+func (p *FrameworkProperty) addIncludeInTagsOption(options []PropertyOption) []PropertyOption {
 	if !p.IncludeInTags.IsNull() && !p.IncludeInTags.IsUnknown() && !p.IncludeInTags.ValueBool() {
 		return append(options, WithExcludeFromTags())
 	}
 	return options
 }
 
-func (p *FrameworkProperty) addMinLengthOption(options []func(*Property)) []func(*Property) {
+func (p *FrameworkProperty) addMinLengthOption(options []PropertyOption) []PropertyOption {
 	if !p.MinLength.IsNull() && !p.MinLength.IsUnknown() {
 		return append(options, WithMinLength(int(p.MinLength.ValueInt64())))
 	}
 	return options
 }
 
-func (p *FrameworkProperty) addMaxLengthOption(options []func(*Property)) []func(*Property) {
+func (p *FrameworkProperty) addMaxLengthOption(options []PropertyOption) []PropertyOption {
 	if !p.MaxLength.IsNull() && !p.MaxLength.IsUnknown() {
 		return append(options, WithMaxLength(int(p.MaxLength.ValueInt64())))
 	}
 	return options
 }
 
-func (p *FrameworkProperty) addValidationRegexOption(options []func(*Property)) []func(*Property) {
+func (p *FrameworkProperty) addValidationRegexOption(options []PropertyOption) []PropertyOption {
 	if !p.ValidationRegex.IsNull() && !p.ValidationRegex.IsUnknown() {
 		return append(options, WithValidationRegex(p.ValidationRegex.ValueString()))
 	}
 	return options
 }
 
+func (p *FrameworkProperty) addTagsKeyCaseOption(options []PropertyOption) []PropertyOption {
+	if !p.TagsKeyCase.IsNull() && !p.TagsKeyCase.IsUnknown() {
+		if caseType, err := cases.FromString(p.TagsKeyCase.ValueString()); err == nil {
+			options = append(options, WithPropertyTagsKeyCase(caseType))
+		}
+	}
+	return options
+}
+
+func (p *FrameworkProperty) addTagsValueCaseOption(options []PropertyOption) []PropertyOption {
+	if !p.TagsValueCase.IsNull() && !p.TagsValueCase.IsUnknown() {
+		if caseType, err := cases.FromString(p.TagsValueCase.ValueString()); err == nil {
+			options = append(options, WithPropertyTagsValueCase(caseType))
+		}
+	}
+	return options
+}
+
 func (p *FrameworkProperty) ToModel(name string) (*Property, error) {
-	options := []func(*Property){}
+	options := []PropertyOption{}
 
 	options = p.addRequiredOption(options)
 	options = p.addIncludeInTagsOption(options)
 	options = p.addMinLengthOption(options)
 	options = p.addMaxLengthOption(options)
 	options = p.addValidationRegexOption(options)
+	options = p.addTagsKeyCaseOption(options)
+	options = p.addTagsValueCaseOption(options)
 
 	return NewProperty(name, options...), nil
 }
@@ -66,16 +89,25 @@ func (p FrameworkProperty) Types() map[string]attr.Type {
 		"max_length":       types.Int64Type,
 		"min_length":       types.Int64Type,
 		"required":         types.BoolType,
+		"tags_key_case":    types.StringType,
+		"tags_value_case":  types.StringType,
 		"validation_regex": types.StringType,
 	}
 }
 
 func (p FrameworkProperty) FromConfigProperty(cp Property) FrameworkProperty {
-	return FrameworkProperty{
+	fp := FrameworkProperty{
 		IncludeInTags:   types.BoolValue(cp.IncludeInTags),
 		MaxLength:       types.Int64Value(int64(cp.MaxLength)),
 		MinLength:       types.Int64Value(int64(cp.MinLength)),
 		Required:        types.BoolValue(cp.Required),
 		ValidationRegex: types.StringValue(cp.ValidationRegex),
 	}
+	if cp.TagsKeyCase != nil {
+		fp.TagsKeyCase = types.StringValue(cp.TagsKeyCase.String())
+	}
+	if cp.TagsValueCase != nil {
+		fp.TagsValueCase = types.StringValue(cp.TagsValueCase.String())
+	}
+	return fp
 }

--- a/internal/model/framework_property.go
+++ b/internal/model/framework_property.go
@@ -83,7 +83,7 @@ func (p *FrameworkProperty) ToModel(name string) (*Property, error) {
 	return NewProperty(name, options...), nil
 }
 
-func (p FrameworkProperty) Types() map[string]attr.Type {
+func (p *FrameworkProperty) Types() map[string]attr.Type {
 	return map[string]attr.Type{
 		"include_in_tags":  types.BoolType,
 		"max_length":       types.Int64Type,
@@ -95,7 +95,7 @@ func (p FrameworkProperty) Types() map[string]attr.Type {
 	}
 }
 
-func (p FrameworkProperty) FromConfigProperty(cp Property) FrameworkProperty {
+func (p *FrameworkProperty) FromConfigProperty(cp *Property) FrameworkProperty {
 	fp := FrameworkProperty{
 		IncludeInTags:   types.BoolValue(cp.IncludeInTags),
 		MaxLength:       types.Int64Value(int64(cp.MaxLength)),

--- a/internal/model/property.go
+++ b/internal/model/property.go
@@ -5,7 +5,12 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+
+	"github.com/cloudposse/terraform-provider-context/pkg/cases"
 )
+
+// PropertyOption is a function that modifies a Property.
+type PropertyOption func(*Property)
 
 type Property struct {
 	IncludeInTags   bool
@@ -13,6 +18,8 @@ type Property struct {
 	MinLength       int
 	Name            string
 	Required        bool
+	TagsKeyCase     *cases.Case
+	TagsValueCase   *cases.Case
 	ValidationRegex string
 }
 
@@ -91,13 +98,15 @@ func validateRegex(regex string, value string, propertyName string) error {
 	return nil
 }
 
-func NewProperty(name string, options ...func(*Property)) *Property {
+func NewProperty(name string, options ...PropertyOption) *Property {
 	defaults := &Property{
 		IncludeInTags:   true,
 		MaxLength:       0,
 		MinLength:       0,
 		Name:            name,
 		Required:        false,
+		TagsKeyCase:     nil,
+		TagsValueCase:   nil,
 		ValidationRegex: "",
 	}
 
@@ -135,5 +144,19 @@ func WithMaxLength(maxLength int) func(*Property) {
 func WithValidationRegex(regex string) func(*Property) {
 	return func(obj *Property) {
 		obj.ValidationRegex = regex
+	}
+}
+
+// WithPropertyTagsKeyCase sets the tags key case for the property.
+func WithPropertyTagsKeyCase(caseType cases.Case) func(*Property) {
+	return func(obj *Property) {
+		obj.TagsKeyCase = &caseType
+	}
+}
+
+// WithPropertyTagsValueCase sets the tags value case for the property.
+func WithPropertyTagsValueCase(caseType cases.Case) func(*Property) {
+	return func(obj *Property) {
+		obj.TagsValueCase = &caseType
 	}
 }

--- a/internal/model/provider_config.go
+++ b/internal/model/provider_config.go
@@ -270,7 +270,7 @@ func (c *ProviderConfig) GetTags(values map[string]string, tagsKeyCase *cases.Ca
 	tags := map[string]string{}
 	mergedValues := c.GetMergedValues(values)
 	validationErrors := c.ValidateProperties(mergedValues)
-	megedTagsKeyCase := c.GetMergedTagsKeyCase(tagsKeyCase)
+	mergedTagsKeyCase := c.GetMergedTagsKeyCase(tagsKeyCase)
 	mergedTagsValueCase := c.GetMergedTagsValueCase(tagsValueCase)
 
 	if len(validationErrors) > 0 {
@@ -279,7 +279,16 @@ func (c *ProviderConfig) GetTags(values map[string]string, tagsKeyCase *cases.Ca
 
 	for _, p := range c.properties {
 		if p.IncludeInTags {
-			key, value := getCasedTag(p.Name, mergedValues[p.Name], megedTagsKeyCase, mergedTagsValueCase)
+			// Use property-specific cases if available, otherwise use merged cases
+			keyCase := mergedTagsKeyCase
+			if p.TagsKeyCase != nil {
+				keyCase = *p.TagsKeyCase
+			}
+			valueCase := mergedTagsValueCase
+			if p.TagsValueCase != nil {
+				valueCase = *p.TagsValueCase
+			}
+			key, value := getCasedTag(p.Name, mergedValues[p.Name], keyCase, valueCase)
 			if value != "" {
 				tags[key] = value
 			}

--- a/internal/model/provider_config.go
+++ b/internal/model/provider_config.go
@@ -278,20 +278,21 @@ func (c *ProviderConfig) GetTags(values map[string]string, tagsKeyCase *cases.Ca
 	}
 
 	for _, p := range c.properties {
-		if p.IncludeInTags {
-			// Use property-specific cases if available, otherwise use merged cases
-			keyCase := mergedTagsKeyCase
-			if p.TagsKeyCase != nil {
-				keyCase = *p.TagsKeyCase
-			}
-			valueCase := mergedTagsValueCase
-			if p.TagsValueCase != nil {
-				valueCase = *p.TagsValueCase
-			}
-			key, value := getCasedTag(p.Name, mergedValues[p.Name], keyCase, valueCase)
-			if value != "" {
-				tags[key] = value
-			}
+		if !p.IncludeInTags {
+			continue
+		}
+		// Use property-specific cases if available, otherwise use merged cases
+		keyCase := mergedTagsKeyCase
+		if p.TagsKeyCase != nil {
+			keyCase = *p.TagsKeyCase
+		}
+		valueCase := mergedTagsValueCase
+		if p.TagsValueCase != nil {
+			valueCase = *p.TagsValueCase
+		}
+		key, value := getCasedTag(p.Name, mergedValues[p.Name], keyCase, valueCase)
+		if value != "" {
+			tags[key] = value
 		}
 	}
 	return tags, nil

--- a/internal/provider/config_data_source.go
+++ b/internal/provider/config_data_source.go
@@ -125,11 +125,13 @@ func (d *ConfigDataSource) setBasicConfig(config *ConfigDataSourceModel) {
 func (d *ConfigDataSource) setProperties(ctx context.Context, config *ConfigDataSourceModel, resp *datasource.ReadResponse) {
 	properties := d.providerData.ProviderConfig.GetProperties()
 	propMap := make(map[string]model.FrameworkProperty, len(properties))
-	for _, v := range properties {
-		propMap[v.Name] = model.FrameworkProperty{}.FromConfigProperty(v)
+	fp := &model.FrameworkProperty{}
+	for _, prop := range properties {
+		property := prop // Create a new variable to avoid memory aliasing
+		propMap[property.Name] = fp.FromConfigProperty(&property)
 	}
 
-	props, diag := types.MapValueFrom(ctx, types.ObjectType{AttrTypes: model.FrameworkProperty{}.Types()}, propMap)
+	props, diag := types.MapValueFrom(ctx, types.ObjectType{AttrTypes: fp.Types()}, propMap)
 	resp.Diagnostics.Append(diag...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/constants.go
+++ b/internal/provider/constants.go
@@ -1,0 +1,19 @@
+package provider
+
+const (
+	// CaseNone represents no case transformation.
+	CaseNone = "none"
+	// CaseCamel represents camelCase transformation.
+	CaseCamel = "camel"
+	// CaseLower represents lowercase transformation.
+	CaseLower = "lower"
+	// CaseSnake represents snake_case transformation.
+	CaseSnake = "snake"
+	// CaseTitle represents TitleCase transformation.
+	CaseTitle = "title"
+	// CaseUpper represents UPPERCASE transformation.
+	CaseUpper = "upper"
+)
+
+// ValidCases contains all valid case values.
+var ValidCases = []string{CaseNone, CaseCamel, CaseLower, CaseSnake, CaseTitle, CaseUpper}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -69,14 +69,18 @@ func (p *ContextProvider) Schema(ctx context.Context, req provider.SchemaRequest
 				Optional:            true,
 			},
 			"tags_key_case": schema.StringAttribute{
-				MarkdownDescription: "The case to use for the keys of tags created by the provider. Valid values are: none, camel, lower, snake, title, upper.",
 				Optional:            true,
-				Validators:          []validator.String{stringvalidator.OneOf("none", "camel", "lower", "snake", "title", "upper")},
+				MarkdownDescription: "The case to use for the keys of tags created by the provider. Valid values are: none, camel, lower, snake, title, upper.",
+				Validators: []validator.String{
+					stringvalidator.OneOf(ValidCases...),
+				},
 			},
 			"tags_value_case": schema.StringAttribute{
-				MarkdownDescription: "The case to use for the values of tags created by the provider. Valid values are: none, camel, lower, snake, title, upper.",
 				Optional:            true,
-				Validators:          []validator.String{stringvalidator.OneOf("none", "camel", "lower", "snake", "title", "upper")},
+				MarkdownDescription: "The case to use for the values of tags created by the provider. Valid values are: none, camel, lower, snake, title, upper.",
+				Validators: []validator.String{
+					stringvalidator.OneOf(ValidCases...),
+				},
 			},
 			"values": schema.MapAttribute{
 				MarkdownDescription: "A map of values to use for labels created by the provider.",

--- a/internal/provider/schema.go
+++ b/internal/provider/schema.go
@@ -87,3 +87,31 @@ func getPropertiesDSSchema() dsschema.NestedAttributeObject {
 		},
 	}
 }
+
+func GetProviderSchema() map[string]dsschema.Attribute {
+	return map[string]dsschema.Attribute{
+		"delimiter": dsschema.StringAttribute{
+			Optional:            true,
+			MarkdownDescription: "The delimiter to use between label elements.",
+		},
+		"enabled": dsschema.BoolAttribute{
+			Optional:            true,
+			MarkdownDescription: "Set to false to prevent the module from creating any resources.",
+		},
+		"tags_key_case": dsschema.StringAttribute{
+			Optional:            true,
+			MarkdownDescription: "The case to use for the keys of tags created by the provider. Valid values are: none, camel, lower, snake, title, upper.",
+			Validators: []validator.String{
+				stringvalidator.OneOf(ValidCases...),
+			},
+		},
+		"tags_value_case": dsschema.StringAttribute{
+			Optional:            true,
+			MarkdownDescription: "The case to use for the values of tags created by the provider. Valid values are: none, camel, lower, snake, title, upper.",
+			Validators: []validator.String{
+				stringvalidator.OneOf(ValidCases...),
+			},
+		},
+		// ... rest of the schema ...
+	}
+}

--- a/internal/provider/schema.go
+++ b/internal/provider/schema.go
@@ -2,10 +2,10 @@ package provider
 
 import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	dsschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
-	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 )
 
 func getPropertiesSchema() schema.NestedAttributeObject {

--- a/internal/provider/schema.go
+++ b/internal/provider/schema.go
@@ -36,12 +36,16 @@ func getPropertiesSchema() schema.NestedAttributeObject {
 			"tags_key_case": schema.StringAttribute{
 				MarkdownDescription: "The case to use for the key of this property in tags. If not set, uses the provider's tags_key_case setting. Valid values are: none, camel, lower, snake, title, upper.",
 				Optional:            true,
-				Validators:          []validator.String{stringvalidator.OneOf("none", "camel", "lower", "snake", "title", "upper")},
+				Validators: []validator.String{
+					stringvalidator.OneOf(ValidCases...),
+				},
 			},
 			"tags_value_case": schema.StringAttribute{
 				MarkdownDescription: "The case to use for the value of this property in tags. If not set, uses the provider's tags_value_case setting. Valid values are: none, camel, lower, snake, title, upper.",
 				Optional:            true,
-				Validators:          []validator.String{stringvalidator.OneOf("none", "camel", "lower", "snake", "title", "upper")},
+				Validators: []validator.String{
+					stringvalidator.OneOf(ValidCases...),
+				},
 			},
 			"validation_regex": schema.StringAttribute{
 				MarkdownDescription: "A regular expression to validate the property.",
@@ -73,12 +77,16 @@ func getPropertiesDSSchema() dsschema.NestedAttributeObject {
 			"tags_key_case": dsschema.StringAttribute{
 				MarkdownDescription: "The case to use for the key of this property in tags.",
 				Optional:            true,
-				Validators:          []validator.String{stringvalidator.OneOf("none", "camel", "lower", "snake", "title", "upper")},
+				Validators: []validator.String{
+					stringvalidator.OneOf(ValidCases...),
+				},
 			},
 			"tags_value_case": dsschema.StringAttribute{
 				MarkdownDescription: "The case to use for the value of this property in tags.",
 				Optional:            true,
-				Validators:          []validator.String{stringvalidator.OneOf("none", "camel", "lower", "snake", "title", "upper")},
+				Validators: []validator.String{
+					stringvalidator.OneOf(ValidCases...),
+				},
 			},
 			"validation_regex": dsschema.StringAttribute{
 				MarkdownDescription: "A regular expression to validate the property.",

--- a/internal/provider/schema.go
+++ b/internal/provider/schema.go
@@ -73,10 +73,12 @@ func getPropertiesDSSchema() dsschema.NestedAttributeObject {
 			"tags_key_case": dsschema.StringAttribute{
 				MarkdownDescription: "The case to use for the key of this property in tags.",
 				Optional:            true,
+				Validators:          []validator.String{stringvalidator.OneOf("none", "camel", "lower", "snake", "title", "upper")},
 			},
 			"tags_value_case": dsschema.StringAttribute{
 				MarkdownDescription: "The case to use for the value of this property in tags.",
 				Optional:            true,
+				Validators:          []validator.String{stringvalidator.OneOf("none", "camel", "lower", "snake", "title", "upper")},
 			},
 			"validation_regex": dsschema.StringAttribute{
 				MarkdownDescription: "A regular expression to validate the property.",

--- a/internal/provider/schema.go
+++ b/internal/provider/schema.go
@@ -5,6 +5,7 @@ import (
 	dsschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 )
 
 func getPropertiesSchema() schema.NestedAttributeObject {
@@ -32,6 +33,16 @@ func getPropertiesSchema() schema.NestedAttributeObject {
 				MarkdownDescription: "A flag to indicate if the property is required.",
 				Optional:            true,
 			},
+			"tags_key_case": schema.StringAttribute{
+				MarkdownDescription: "The case to use for the key of this property in tags. If not set, uses the provider's tags_key_case setting. Valid values are: none, camel, lower, snake, title, upper.",
+				Optional:            true,
+				Validators:          []validator.String{stringvalidator.OneOf("none", "camel", "lower", "snake", "title", "upper")},
+			},
+			"tags_value_case": schema.StringAttribute{
+				MarkdownDescription: "The case to use for the value of this property in tags. If not set, uses the provider's tags_value_case setting. Valid values are: none, camel, lower, snake, title, upper.",
+				Optional:            true,
+				Validators:          []validator.String{stringvalidator.OneOf("none", "camel", "lower", "snake", "title", "upper")},
+			},
 			"validation_regex": schema.StringAttribute{
 				MarkdownDescription: "A regular expression to validate the property.",
 				Optional:            true,
@@ -57,6 +68,14 @@ func getPropertiesDSSchema() dsschema.NestedAttributeObject {
 			},
 			"required": dsschema.BoolAttribute{
 				MarkdownDescription: "A flag to indicate if the property is required.",
+				Optional:            true,
+			},
+			"tags_key_case": dsschema.StringAttribute{
+				MarkdownDescription: "The case to use for the key of this property in tags.",
+				Optional:            true,
+			},
+			"tags_value_case": dsschema.StringAttribute{
+				MarkdownDescription: "The case to use for the value of this property in tags.",
 				Optional:            true,
 			},
 			"validation_regex": dsschema.StringAttribute{

--- a/internal/provider/tags_data_source.go
+++ b/internal/provider/tags_data_source.go
@@ -59,14 +59,18 @@ func (d *TagsDataSource) Schema(ctx context.Context, req datasource.SchemaReques
 				ElementType:         types.MapType{ElemType: types.StringType},
 			},
 			"tags_key_case": schema.StringAttribute{
-				MarkdownDescription: "The case to use for the keys of tags created by the provider. Valid values are: none, camel, lower, snake, title, upper.",
 				Optional:            true,
-				Validators:          []validator.String{stringvalidator.OneOf("none", "camel", "lower", "snake", "title", "upper")},
+				MarkdownDescription: "The case to use for the keys of tags created by the provider. Valid values are: none, camel, lower, snake, title, upper.",
+				Validators: []validator.String{
+					stringvalidator.OneOf(ValidCases...),
+				},
 			},
 			"tags_value_case": schema.StringAttribute{
-				MarkdownDescription: "The case to use for the values of tags created by the provider. Valid values are: none, camel, lower, snake, title, upper.",
 				Optional:            true,
-				Validators:          []validator.String{stringvalidator.OneOf("none", "camel", "lower", "snake", "title", "upper")},
+				MarkdownDescription: "The case to use for the values of tags created by the provider. Valid values are: none, camel, lower, snake, title, upper.",
+				Validators: []validator.String{
+					stringvalidator.OneOf(ValidCases...),
+				},
 			},
 			"values": schema.MapAttribute{
 				MarkdownDescription: "Map of values to override or add to the context when creating the label.",


### PR DESCRIPTION
## what

Add the ability to configure the casing of tag name and tag value on a per-tag basis

## why

To allow tags to be configurable so that, for example, a property can be named `lob` yet its name in tags can be `LOB` without all tags from the context needing to be upper-cased.