### PR TITLE
initial extra params

### DIFF
--- a/internal/provider/tags_data_source_test.go
+++ b/internal/provider/tags_data_source_test.go
@@ -56,6 +56,21 @@ func TestAccTagsDataSource(t *testing.T) {
 					resource.TestCheckResourceAttr("data.context_tags.test", "tags.NAME", "example"),
 				),
 			},
+			{
+				Config: testAccTagsReplaceCfg,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.context_tags.test", "tags_as_list.0.Key", "Name"),
+					resource.TestCheckResourceAttr("data.context_tags.test", "tags_as_list.1.Key", "Namespace"),
+					resource.TestCheckResourceAttr("data.context_tags.test", "tags_as_list.2.Key", "Stage"),
+					resource.TestCheckResourceAttr("data.context_tags.test", "tags_as_list.3.Key", "Tenant"),
+					resource.TestCheckResourceAttr("data.context_tags.test", "tags_as_list.4.Key", "Tenant"),
+					resource.TestCheckResourceAttr("data.context_tags.test", "tags_as_list.0.Value", "example"),
+					resource.TestCheckResourceAttr("data.context_tags.test", "tags_as_list.1.Value", "cp"),
+					resource.TestCheckResourceAttr("data.context_tags.test", "tags_as_list.2.Value", "prod"),
+					resource.TestCheckResourceAttr("data.context_tags.test", "tags_as_list.3.Value", "core"),
+					resource.TestCheckResourceAttr("data.context_tags.test", "tags_as_list.4.Value", "foo-bar-baz"),
+				),
+			},
 		},
 	})
 }
@@ -399,6 +414,34 @@ provider "context" {
     "Tenant" = "core"
     "Stage" = "prod"
     "Name"  = "example"
+  }
+}
+
+
+data "context_tags" "test" {
+}
+`
+const testAccTagsReplaceCfg = `
+provider "context" {
+  properties = {
+    Namespace = {}
+    Tenant    = {}
+    Stage     = {}
+    Name      = {}
+    ComponentPath      = {}
+  }
+
+  values = {
+    "Namespace" = "cloudposse"
+    "Tenant" = "core"
+    "Stage" = "prod"
+    "Name"  = "example"
+	"ComponentPath" = "foo/bar/baz"
+  }
+
+  replacement_map = {
+	"cloudposse" = "cp"
+	"/" = "-"
   }
 }
 


### PR DESCRIPTION
This pull request introduces several changes to the `internal/provider/tags_data_source.go` file to add a new feature for tag replacement. Additionally, it updates the corresponding test file to ensure the new functionality is properly tested. The most important changes include the addition of a replacement map to the tags data source model, schema, and logic, as well as new tests to verify the feature.

### New Feature: Tag Replacement

* [`internal/provider/tags_data_source.go`](diffhunk://#diff-8d1c8c665382936291675d1bec15d3b3de0a698228d7b0630da93f0f704e2452R40): Added a `ReplacementMap` field to the `TagsDataSourceModel` struct to support tag replacements.
* [`internal/provider/tags_data_source.go`](diffhunk://#diff-8d1c8c665382936291675d1bec15d3b3de0a698228d7b0630da93f0f704e2452R86-R90): Updated the `Schema` method to include the `replacement_map` attribute, allowing users to define a map of strings to replace in the tags.
* [`internal/provider/tags_data_source.go`](diffhunk://#diff-8d1c8c665382936291675d1bec15d3b3de0a698228d7b0630da93f0f704e2452R131-R144): Added the `getLocalReplacements` method to handle the replacement logic, which processes the tags according to the provided replacement map.
* [`internal/provider/tags_data_source.go`](diffhunk://#diff-8d1c8c665382936291675d1bec15d3b3de0a698228d7b0630da93f0f704e2452R216-R220): Modified the `Read` method to apply the tag replacements by calling the `getLocalReplacements` method.

### Testing

* [`internal/provider/tags_data_source_test.go`](diffhunk://#diff-62d17f87e49fe70a31db032bad4c2698b81b41c9557bb310ece39e220fd8ae42R59-R73): Added a new test configuration and checks to verify the tag replacement functionality, ensuring that tags are correctly replaced according to the specified replacement map. [[1]](diffhunk://#diff-62d17f87e49fe70a31db032bad4c2698b81b41c9557bb310ece39e220fd8ae42R59-R73) [[2]](diffhunk://#diff-62d17f87e49fe70a31db032bad4c2698b81b41c9557bb310ece39e220fd8ae42R421-R448)